### PR TITLE
Alternative to composer-merge plugin

### DIFF
--- a/Dockerfile.composer
+++ b/Dockerfile.composer
@@ -7,9 +7,10 @@ COPY composer.json \
     symfony.lock \
     ./
 
+COPY vendor-extra/ vendor-extra/
+
 RUN composer --no-interaction install ${composer_dev_arg} --ignore-platform-reqs --no-autoloader --no-suggest --prefer-dist
 
 COPY src/ src/
-COPY vendor-extra/ vendor-extra/
 
 RUN composer --no-interaction dump-autoload ${composer_dev_arg} --classmap-authoritative

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": "^7.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "libero/content-page-bundle": "0.0.1",
         "symfony/config": "^4.1",
         "symfony/console": "^4.1",
         "symfony/dependency-injection": "^4.1",
@@ -23,8 +24,7 @@
         "symfony/http-foundation": "^4.1",
         "symfony/http-kernel": "^4.1",
         "symfony/routing": "^4.1",
-        "symfony/yaml": "^4.1",
-        "wikimedia/composer-merge-plugin": "^1.4"
+        "symfony/yaml": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3",
@@ -38,13 +38,15 @@
         "symfony/polyfill-php70": "*",
         "symfony/polyfill-php71": "*"
     },
-    "extra": {
-        "merge-plugin": {
-            "include": [
-                "vendor-extra/*/composer.json"
-            ]
-        }
+    "scripts": {
+        "test": "phpunit"
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "./vendor-extra/*"
+        }
+    ],
     "config": {
         "platform": {
             "php": "7.2.8"

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,41 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2523ba46ea61fbad0647045fcc59aef1",
+    "content-hash": "5e4c6f368c3afb9eea4e4f047354487e",
     "packages": [
+        {
+            "name": "libero/content-page-bundle",
+            "version": "0.0.1",
+            "dist": {
+                "type": "path",
+                "url": "./vendor-extra/ContentPageBundle",
+                "reference": "058a5cb5a849122e6e57382b0cf5a15853bd6259",
+                "shasum": null
+            },
+            "require": {
+                "php": "^7.2",
+                "symfony/config": "^4.1",
+                "symfony/dependency-injection": "^4.1",
+                "symfony/http-foundation": "^4.1",
+                "symfony/http-kernel": "^4.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.3"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Libero\\ContentPageBundle\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "A Libero content page"
+        },
         {
             "name": "psr/cache",
             "version": "1.0.1",
@@ -1183,55 +1213,6 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2018-07-26T11:24:31+00:00"
-        },
-        {
-            "name": "wikimedia/composer-merge-plugin",
-            "version": "v1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
-                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
-                "reference": "81c6ac72a24a67383419c7eb9aa2b3437f2ab100",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0",
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "composer/composer": "~1.0.0",
-                "jakub-onderka/php-parallel-lint": "~0.8",
-                "phpunit/phpunit": "~4.8|~5.0",
-                "squizlabs/php_codesniffer": "~2.1.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                },
-                "class": "Wikimedia\\Composer\\MergePlugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Wikimedia\\Composer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bryan Davis",
-                    "email": "bd808@wikimedia.org"
-                }
-            ],
-            "description": "Composer plugin to merge multiple composer.json files",
-            "time": "2017-04-25T02:31:25+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e4c6f368c3afb9eea4e4f047354487e",
+    "content-hash": "efa47dff5a359c978c8bd50e5dffd2ef",
     "packages": [
         {
             "name": "libero/content-page-bundle",

--- a/symfony.lock
+++ b/symfony.lock
@@ -2,6 +2,9 @@
     "doctrine/instantiator": {
         "version": "1.1.0"
     },
+    "libero/content-page-bundle": {
+        "version": "0.0.1"
+    },
     "myclabs/deep-copy": {
         "version": "1.8.1"
     },

--- a/vendor-extra/ContentPageBundle/composer.json
+++ b/vendor-extra/ContentPageBundle/composer.json
@@ -2,6 +2,7 @@
     "name": "libero/content-page-bundle",
     "description": "A Libero content page",
     "type": "symfony-bundle",
+    "version": "0.0.1",
     "license": "MIT",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Posting this as an alternative to using composer merge. Aside from not using the merge-logic itself, it also forces `browser` itself define the dependencies it has (and omit those that it doesn't). When it comes to removing the dependency into its own file its just a case of removing it form the filesystem and `composer update`. 

One last point, with the library approach, its likely we will have Bundles (in `/vendor-extra`) that will depend on these libraries (that also live in `/vendor-extra`) at which point, if we don't define them in the `composer.json` file, will be harder to track down later. This is more of a vanilla composer approach.

Bonus to this approach, when we do come to splitting these out into repositories, you can continue to develop them simply by cloning into the `/vendor-extra` locally and it will pick up changes.