### PR TITLE
Allow Symfony Flex to write files anywhere

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -3,10 +3,7 @@ version: '3'
 services:
     composer:
         volumes:
-            - ./config/:/app/config/
-            - ./composer.json:/app/composer.json
-            - ./composer.lock:/app/composer.lock
-            - ./symfony.lock:/app/symfony.lock
+            - ./:/app
             - vendor:/app/vendor
     fpm:
         volumes:


### PR DESCRIPTION
Following https://github.com/libero/browser/pull/4#discussion_r211841634, we should allow Symfony Flex to write changes anywhere in the application.

This can be shown by running `docker-compose run composer composer require behat`, which also makes a variety of changes outside of `config/`.