### PR TITLE
Update vendor-extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
     - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
     - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
     - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"
-    - .travis/check-vendor/extra-updated.sh
+    - .travis/check-vendor-extra-updated.sh
 
 after_success:
     - .travis/push-image.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
     - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
     - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
     - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"
+    - .travis/check-vendor/extra-updated.sh
 
 after_success:
     - .travis/push-image.sh

--- a/.travis/check-vendor-extra-updated.sh
+++ b/.travis/check-vendor-extra-updated.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+output=$(docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app composer update libero/content-page-bundle --with-dependencies --dry-run --no-ansi)
+echo "${output}"
+
+[[ ${output} =~ "Nothing to install or update" ]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,12 +64,16 @@ ENV APP_ENV=test
 
 USER root
 
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN touch .phpcs-cache && \
     chown www-data:www-data .phpcs-cache
 COPY tests/ tests/
-COPY phpcs.xml.dist \
+COPY composer.json \
+    composer.lock \
+    phpcs.xml.dist \
     phpstan.neon.dist \
     phpunit.xml.dist \
+    symfony.lock \
     ./
 COPY --from=composer-dev /app/vendor/ vendor/
 
@@ -88,8 +92,3 @@ USER root
 ENV COMPOSER_ALLOW_SUPERUSER=true
 
 COPY .docker/php-dev.ini ${PHP_INI_DIR}/conf.d/01-app.ini
-COPY --from=composer /usr/bin/composer /usr/bin/composer
-COPY composer.json \
-    composer.lock \
-    symfony.lock \
-    ./

--- a/composer.lock
+++ b/composer.lock
@@ -218,6 +218,61 @@
             "time": "2017-12-01T11:52:02+00:00"
         },
         {
+            "name": "fluentdom/fluentdom",
+            "version": "7.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThomasWeinert/FluentDOM.git",
+                "reference": "91038715a02e50255a289c0532acd6adbfc30bde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM/zipball/91038715a02e50255a289c0532acd6adbfc30bde",
+                "reference": "91038715a02e50255a289c0532acd6adbfc30bde",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=7.0"
+            },
+            "suggest": {
+                "ext-json": "JSON support, needed for several loaders/serializers",
+                "ext-xmlreader": "XMLReader, XML pull parser, read large XMLs",
+                "ext-xmlwriter": "XMLWriter, Write large XMLs",
+                "fluentdom/css-selector": "Allows to use css selectors."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/FluentDOM.php"
+                ],
+                "psr-4": {
+                    "FluentDOM\\": "src/FluentDOM"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "FluentDOM Contributors",
+                    "homepage": "https://github.com/FluentDOM/FluentDOM/contributors"
+                }
+            ],
+            "description": "A fluent api for the php dom extension.",
+            "homepage": "http://fluentdom.org",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "Xpath",
+                "dom",
+                "jquery",
+                "xml"
+            ],
+            "time": "2018-11-11T13:47:41+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "6.3.3",
             "source": {
@@ -404,18 +459,26 @@
             "dist": {
                 "type": "path",
                 "url": "./vendor-extra/ContentPageBundle",
-                "reference": "a334e0f10e447c85dbc6a543dc9d0864a458139a",
+                "reference": "0113b2f981a07386ddd0c732fbabe9f0494ff2c7",
                 "shasum": null
             },
             "require": {
+                "fluentdom/fluentdom": "^7.0",
+                "guzzlehttp/guzzle": "^6.3",
                 "php": "^7.2",
+                "psr/http-message": "^1.0",
                 "symfony/config": "^4.1",
                 "symfony/dependency-injection": "^4.1",
                 "symfony/http-foundation": "^4.1",
-                "symfony/http-kernel": "^4.1"
+                "symfony/http-kernel": "^4.1",
+                "symfony/routing": "^4.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.3"
+                "csa/guzzle-cache-middleware": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php-vfs/php-vfs": "^1.4",
+                "phpunit/phpunit": "^7.3",
+                "symfony/dom-crawler": "^4.1"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -2258,61 +2321,6 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
-        },
-        {
-            "name": "fluentdom/fluentdom",
-            "version": "7.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ThomasWeinert/FluentDOM.git",
-                "reference": "91038715a02e50255a289c0532acd6adbfc30bde"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM/zipball/91038715a02e50255a289c0532acd6adbfc30bde",
-                "reference": "91038715a02e50255a289c0532acd6adbfc30bde",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": ">=7.0"
-            },
-            "suggest": {
-                "ext-json": "JSON support, needed for several loaders/serializers",
-                "ext-xmlreader": "XMLReader, XML pull parser, read large XMLs",
-                "ext-xmlwriter": "XMLWriter, Write large XMLs",
-                "fluentdom/css-selector": "Allows to use css selectors."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/FluentDOM.php"
-                ],
-                "psr-4": {
-                    "FluentDOM\\": "src/FluentDOM"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "FluentDOM Contributors",
-                    "homepage": "https://github.com/FluentDOM/FluentDOM/contributors"
-                }
-            ],
-            "description": "A fluent api for the php dom extension.",
-            "homepage": "http://fluentdom.org",
-            "keywords": [
-                "XMLReader",
-                "XMLWriter",
-                "Xpath",
-                "dom",
-                "jquery",
-                "xml"
-            ],
-            "time": "2018-11-11T13:47:41+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",


### PR DESCRIPTION
As seen in https://github.com/libero/sample-configuration/pull/10#issuecomment-441251558, `composer update libero/content-page-bundle --with-dependencies` needed to be run to update the lock file.

