### PR TITLE
Store the context in the View

### DIFF
--- a/vendor-extra/JatsContentBundle/src/ViewConverter/BoldVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/BoldVisitor.php
@@ -21,9 +21,9 @@ final class BoldVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/FrontArticleTitleContentHeaderVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/FrontArticleTitleContentHeaderVisitor.php
@@ -21,7 +21,7 @@ final class FrontArticleTitleContentHeaderVisitor implements ViewConverterVisito
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
         $title = $object->ownerDocument->xpath()
             ->firstOf('jats:article-meta/jats:title-group/jats:article-title', $object);
@@ -32,7 +32,7 @@ final class FrontArticleTitleContentHeaderVisitor implements ViewConverterVisito
 
         return $view->withArgument(
             'contentTitle',
-            $this->converter->convert($title, '@LiberoPatterns/heading.html.twig', $context)->getArguments()
+            $this->converter->convert($title, '@LiberoPatterns/heading.html.twig', $view->getContext())->getArguments()
         );
     }
 

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/FrontItemTagsVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/FrontItemTagsVisitor.php
@@ -24,7 +24,7 @@ final class FrontItemTagsVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
         /** @var DOMNodeList|Element[] $keywordGroups */
         $keywordGroups = $object->ownerDocument->xpath()
@@ -40,7 +40,7 @@ final class FrontItemTagsVisitor implements ViewConverterVisitor
                 function (View $tagList) : array {
                     return $tagList->getArguments();
                 },
-                $this->convertList($keywordGroups, '@LiberoPatterns/tag-list.html.twig', $context)
+                $this->convertList($keywordGroups, '@LiberoPatterns/tag-list.html.twig', $view->getContext())
             )
         );
     }

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/FrontSubjectGroupContentHeaderVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/FrontSubjectGroupContentHeaderVisitor.php
@@ -31,7 +31,7 @@ final class FrontSubjectGroupContentHeaderVisitor implements ViewConverterVisito
         $this->translator = $translator;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
         /** @var DOMNodeList|Element[] $subjects */
         $subjects = $object->ownerDocument->xpath()->evaluate(
@@ -47,13 +47,16 @@ final class FrontSubjectGroupContentHeaderVisitor implements ViewConverterVisito
             'categories',
             [
                 'attributes' => [
-                    'aria-label' => $this->translate('libero.patterns.content_header.categories.label', $context),
+                    'aria-label' => $this->translate(
+                        'libero.patterns.content_header.categories.label',
+                        $view->getContext()
+                    ),
                 ],
                 'items' => array_map(
                     function (View $link) : array {
                         return ['content' => $link->getArguments()];
                     },
-                    $this->convertList($subjects, '@LiberoPatterns/link.html.twig', $context)
+                    $this->convertList($subjects, '@LiberoPatterns/link.html.twig', $view->getContext())
                 ),
             ]
         );

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/HeadingVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/HeadingVisitor.php
@@ -10,6 +10,7 @@ use Libero\ViewsBundle\Views\SimplifiedVisitor;
 use Libero\ViewsBundle\Views\View;
 use Libero\ViewsBundle\Views\ViewConverter;
 use Libero\ViewsBundle\Views\ViewConverterVisitor;
+use function is_int;
 
 final class HeadingVisitor implements ViewConverterVisitor
 {
@@ -21,13 +22,13 @@ final class HeadingVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        if (isset($context['level'])) {
-            $view = $view->withArgument('level', $context['level']);
+        if (is_int($view->getContext('level'))) {
+            $view = $view->withArgument('level', $view->getContext('level'));
         }
 
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function expectedTemplate() : string

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/HeadingVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/HeadingVisitor.php
@@ -10,7 +10,6 @@ use Libero\ViewsBundle\Views\SimplifiedVisitor;
 use Libero\ViewsBundle\Views\View;
 use Libero\ViewsBundle\Views\ViewConverter;
 use Libero\ViewsBundle\Views\ViewConverterVisitor;
-use function is_int;
 
 final class HeadingVisitor implements ViewConverterVisitor
 {
@@ -24,7 +23,7 @@ final class HeadingVisitor implements ViewConverterVisitor
 
     protected function doVisit(Element $object, View $view) : View
     {
-        if (is_int($view->getContext('level'))) {
+        if ($view->hasContext('level')) {
             $view = $view->withArgument('level', $view->getContext('level'));
         }
 

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/ItalicVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/ItalicVisitor.php
@@ -21,9 +21,9 @@ final class ItalicVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/KeywordGroupTagListVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/KeywordGroupTagListVisitor.php
@@ -31,7 +31,7 @@ final class KeywordGroupTagListVisitor implements ViewConverterVisitor
         $this->translationKeys = $translationKeys;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
         $title = $object->ownerDocument->xpath()
             ->firstOf('jats:title', $object);
@@ -46,11 +46,12 @@ final class KeywordGroupTagListVisitor implements ViewConverterVisitor
         $type = $object->getAttribute('kwd-group-type');
 
         if ($title instanceof Element) {
-            $title = $this->converter->convert($title, '@LiberoPatterns/heading.html.twig', $context)->getArguments();
+            $title = $this->converter->convert($title, '@LiberoPatterns/heading.html.twig', $view->getContext())
+                ->getArguments();
         } elseif (!isset($this->translationKeys[$type])) {
             return $view;
         } else {
-            $title = ['text' => $this->translate($this->translationKeys[$type], $context)];
+            $title = ['text' => $this->translate($this->translationKeys[$type], $view->getContext())];
         }
 
         return $view
@@ -62,7 +63,7 @@ final class KeywordGroupTagListVisitor implements ViewConverterVisitor
                         function (View $link) : array {
                             return ['content' => $link->getArguments()];
                         },
-                        $this->convertList($keywords, '@LiberoPatterns/link.html.twig', $context)
+                        $this->convertList($keywords, '@LiberoPatterns/link.html.twig', $view->getContext())
                     ),
                 ]
             );

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/LinkVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/LinkVisitor.php
@@ -23,9 +23,9 @@ final class LinkVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function expectedTemplate() : string

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/ParagraphVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/ParagraphVisitor.php
@@ -23,9 +23,9 @@ final class ParagraphVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/SectionVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/SectionVisitor.php
@@ -13,7 +13,6 @@ use Libero\ViewsBundle\Views\View;
 use Libero\ViewsBundle\Views\ViewConverter;
 use Libero\ViewsBundle\Views\ViewConverterVisitor;
 use function array_map;
-use function is_int;
 use function iterator_to_array;
 
 final class SectionVisitor implements ViewConverterVisitor
@@ -30,7 +29,7 @@ final class SectionVisitor implements ViewConverterVisitor
 
     protected function doVisit(Element $object, View $view) : View
     {
-        if (!is_int($view->getContext('level'))) {
+        if ($view->hasContext('level')) {
             $view = $view->withContext(['level' => 1]);
         }
 

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/SubVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/SubVisitor.php
@@ -21,9 +21,9 @@ final class SubVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/JatsContentBundle/src/ViewConverter/SupVisitor.php
+++ b/vendor-extra/JatsContentBundle/src/ViewConverter/SupVisitor.php
@@ -21,9 +21,9 @@ final class SupVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/BoldVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/BoldVisitorTest.php
@@ -25,12 +25,11 @@ final class BoldVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class BoldVisitorTest extends TestCase
 
         $element = $this->loadElement('<bold xmlns="http://jats.nlm.nih.gov">foo</bold>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class BoldVisitorTest extends TestCase
 
         $element = $this->loadElement('<bold xmlns="http://jats.nlm.nih.gov">foo</bold>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class BoldVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/bold.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/FrontArticleTitleContentHeaderVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/FrontArticleTitleContentHeaderVisitorTest.php
@@ -25,12 +25,11 @@ final class FrontArticleTitleContentHeaderVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -59,12 +58,11 @@ final class FrontArticleTitleContentHeaderVisitorTest extends TestCase
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -76,16 +74,11 @@ XML
 
         $element = $this->loadElement('<front xmlns="http://jats.nlm.nih.gov"><article-meta/></front>');
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/content-header.html.twig'),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -107,17 +100,15 @@ XML
 </front>
 XML
         );
-
-        $newContext = [];
+        ;
         $view = $visitor->visit(
             $element,
-            new View('@LiberoPatterns/content-header.html.twig', ['contentTitle' => 'bar']),
-            $newContext
+            new View('@LiberoPatterns/content-header.html.twig', ['contentTitle' => 'bar'])
         );
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertSame(['contentTitle' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -140,8 +131,9 @@ XML
 XML
         );
 
-        $newContext = ['bar' => 'baz'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'), $newContext);
+        $context = ['bar' => 'baz'];
+
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -154,6 +146,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['bar' => 'baz'], $newContext);
+        $this->assertSame(['bar' => 'baz'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/FrontItemTagsVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/FrontItemTagsVisitorTest.php
@@ -25,12 +25,11 @@ final class FrontItemTagsVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/item-tags.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/item-tags.html.twig'));
 
         $this->assertSame('@LiberoPatterns/item-tags.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -59,12 +58,11 @@ final class FrontItemTagsVisitorTest extends TestCase
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -76,16 +74,11 @@ XML
 
         $element = $this->loadElement('<front xmlns="http://jats.nlm.nih.gov"><article-meta/></front>');
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/item-tags.html.twig'),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/item-tags.html.twig'));
 
         $this->assertSame('@LiberoPatterns/item-tags.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -108,16 +101,11 @@ XML
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/item-tags.html.twig', ['groups' => 'bar']),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/item-tags.html.twig', ['groups' => 'bar']));
 
         $this->assertSame('@LiberoPatterns/item-tags.html.twig', $view->getTemplate());
         $this->assertSame(['groups' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -146,8 +134,8 @@ XML
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/item-tags.html.twig'), $newContext);
+        $context = ['qux' => 'quux'];
+        $view = $visitor->visit($element, new View('@LiberoPatterns/item-tags.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/item-tags.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -167,6 +155,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/FrontSubjectGroupContentHeaderVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/FrontSubjectGroupContentHeaderVisitorTest.php
@@ -28,12 +28,11 @@ final class FrontSubjectGroupContentHeaderVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -64,12 +63,11 @@ final class FrontSubjectGroupContentHeaderVisitorTest extends TestCase
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -94,16 +92,11 @@ XML
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/content-header.html.twig'),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -128,16 +121,14 @@ XML
 XML
         );
 
-        $newContext = [];
         $view = $visitor->visit(
             $element,
-            new View('@LiberoPatterns/content-header.html.twig', ['categories' => 'bar']),
-            $newContext
+            new View('@LiberoPatterns/content-header.html.twig', ['categories' => 'bar'])
         );
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertSame(['categories' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -175,8 +166,8 @@ XML
 XML
         );
 
-        $newContext = ['lang' => 'es'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'), $newContext);
+        $context = ['lang' => 'es'];
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -215,6 +206,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['lang' => 'es'], $newContext);
+        $this->assertSame(['lang' => 'es'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/HeadingVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/HeadingVisitorTest.php
@@ -24,12 +24,11 @@ final class HeadingVisitorTest extends TestCase
 
         $element = $this->loadElement('<article-title xmlns="http://jats.nlm.nih.gov">foo</article-title>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -41,16 +40,11 @@ final class HeadingVisitorTest extends TestCase
 
         $element = $this->loadElement('<article-title xmlns="http://jats.nlm.nih.gov">foo</article-title>');
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/heading.html.twig', ['text' => 'bar']),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig', ['text' => 'bar']));
 
         $this->assertSame('@LiberoPatterns/heading.html.twig', $view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -62,13 +56,13 @@ final class HeadingVisitorTest extends TestCase
         $visitor = new HeadingVisitor($this->createDumpingConverter());
 
         $element = $this->loadElement($xml);
+        $context = ['qux' => 'quux'];
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/heading.html.twig', $view->getTemplate());
         $this->assertEquals(['text' => $expectedText], $view->getArguments());
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 
     public function textProvider() : iterable
@@ -153,11 +147,10 @@ XML
 
         $element = $this->loadElement('<p xmlns="http://jats.nlm.nih.gov">foo</p>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig'));
 
         $this->assertSame('@LiberoPatterns/heading.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/ItalicVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/ItalicVisitorTest.php
@@ -25,12 +25,11 @@ final class ItalicVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class ItalicVisitorTest extends TestCase
 
         $element = $this->loadElement('<italic xmlns="http://jats.nlm.nih.gov">foo</italic>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class ItalicVisitorTest extends TestCase
 
         $element = $this->loadElement('<italic xmlns="http://jats.nlm.nih.gov">foo</italic>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class ItalicVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/italic.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/KeywordGroupTagListVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/KeywordGroupTagListVisitorTest.php
@@ -28,12 +28,11 @@ final class KeywordGroupTagListVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/tag-list.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/tag-list.html.twig'));
 
         $this->assertSame('@LiberoPatterns/tag-list.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -60,12 +59,11 @@ final class KeywordGroupTagListVisitorTest extends TestCase
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -77,16 +75,11 @@ XML
 
         $element = $this->loadElement('<kwd-group xmlns="http://jats.nlm.nih.gov"><x>foo</x></kwd-group>');
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/tag-list.html.twig'),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/tag-list.html.twig'));
 
         $this->assertSame('@LiberoPatterns/tag-list.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -107,16 +100,11 @@ XML
 XML
         );
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/tag-list.html.twig', ['list' => 'qux']),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/tag-list.html.twig', ['list' => 'qux']));
 
         $this->assertSame('@LiberoPatterns/tag-list.html.twig', $view->getTemplate());
         $this->assertSame(['list' => 'qux'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -142,13 +130,13 @@ XML
         $visitor = new KeywordGroupTagListVisitor($this->createDumpingConverter(), $translator, $translationKeys);
 
         $element = $this->loadElement($xml);
+        $context = ['lang' => 'es'];
 
-        $newContext = ['lang' => 'es'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/tag-list.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/tag-list.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/tag-list.html.twig', $view->getTemplate());
         $this->assertEquals($expectedArguments, $view->getArguments());
-        $this->assertSame(['lang' => 'es'], $newContext);
+        $this->assertSame(['lang' => 'es'], $view->getContext());
     }
 
     public function listProvider() : iterable

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/LinkVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/LinkVisitorTest.php
@@ -24,12 +24,11 @@ final class LinkVisitorTest extends TestCase
 
         $element = $this->loadElement('<ext-link xmlns="http://jats.nlm.nih.gov">foo</ext-link>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -41,12 +40,11 @@ final class LinkVisitorTest extends TestCase
 
         $element = $this->loadElement('<ext-link xmlns="http://jats.nlm.nih.gov">foo</ext-link>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -59,12 +57,12 @@ final class LinkVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/link.html.twig'), $newContext);
+        $context = ['qux' => 'quux'];
+        $view = $visitor->visit($element, new View('@LiberoPatterns/link.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/link.html.twig', $view->getTemplate());
         $this->assertEquals(['text' => $expectedText], $view->getArguments());
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 
     public function textProvider() : iterable
@@ -149,11 +147,10 @@ XML
 
         $element = $this->loadElement('<p xmlns="http://jats.nlm.nih.gov">foo</p>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/link.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/link.html.twig'));
 
         $this->assertSame('@LiberoPatterns/link.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/ParagraphVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/ParagraphVisitorTest.php
@@ -25,12 +25,11 @@ final class ParagraphVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class ParagraphVisitorTest extends TestCase
 
         $element = $this->loadElement('<p xmlns="http://jats.nlm.nih.gov">foo</p>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class ParagraphVisitorTest extends TestCase
 
         $element = $this->loadElement('<p xmlns="http://jats.nlm.nih.gov">foo</p>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class ParagraphVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/paragraph.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/SectionVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/SectionVisitorTest.php
@@ -25,12 +25,11 @@ final class SectionVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class SectionVisitorTest extends TestCase
 
         $element = $this->loadElement('<sec xmlns="http://jats.nlm.nih.gov">foo</sec>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class SectionVisitorTest extends TestCase
 
         $element = $this->loadElement('<sec xmlns="http://jats.nlm.nih.gov">foo</sec>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['content' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['content' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['content' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -82,13 +79,13 @@ final class SectionVisitorTest extends TestCase
         $visitor = new SectionVisitor($this->createDumpingConverter());
 
         $element = $this->loadElement($xml);
+        $context = ['level' => 1];
 
-        $newContext = ['level' => 1];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/section.html.twig', $view->getTemplate());
         $this->assertEquals($expectedArguments, $view->getArguments());
-        $this->assertSame(['level' => 1], $newContext);
+        $this->assertSame($context, $view->getContext());
     }
 
     public function contentProvider() : iterable

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/SubVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/SubVisitorTest.php
@@ -25,12 +25,11 @@ final class SubVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class SubVisitorTest extends TestCase
 
         $element = $this->loadElement('<sub xmlns="http://jats.nlm.nih.gov">foo</sub>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class SubVisitorTest extends TestCase
 
         $element = $this->loadElement('<sub xmlns="http://jats.nlm.nih.gov">foo</sub>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class SubVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/sub.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/JatsContentBundle/tests/ViewConverter/SupVisitorTest.php
+++ b/vendor-extra/JatsContentBundle/tests/ViewConverter/SupVisitorTest.php
@@ -25,12 +25,11 @@ final class SupVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class SupVisitorTest extends TestCase
 
         $element = $this->loadElement('<sup xmlns="http://jats.nlm.nih.gov">foo</sup>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class SupVisitorTest extends TestCase
 
         $element = $this->loadElement('<sup xmlns="http://jats.nlm.nih.gov">foo</sup>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class SupVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/sup.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/LiberoContentBundle/src/ViewConverter/BoldVisitor.php
+++ b/vendor-extra/LiberoContentBundle/src/ViewConverter/BoldVisitor.php
@@ -23,9 +23,9 @@ final class BoldVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/LiberoContentBundle/src/ViewConverter/FrontContentHeaderVisitor.php
+++ b/vendor-extra/LiberoContentBundle/src/ViewConverter/FrontContentHeaderVisitor.php
@@ -21,7 +21,7 @@ final class FrontContentHeaderVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
         $title = $object->ownerDocument->xpath()
             ->firstOf('libero:title[1]', $object);
@@ -32,7 +32,9 @@ final class FrontContentHeaderVisitor implements ViewConverterVisitor
 
         return $view->withArgument(
             'contentTitle',
-            $this->converter->convert($title, '@LiberoPatterns/heading.html.twig', $context)->getArguments()
+            $this->converter
+                ->convert($title, '@LiberoPatterns/heading.html.twig', $view->getContext())
+                ->getArguments()
         );
     }
 

--- a/vendor-extra/LiberoContentBundle/src/ViewConverter/ItalicVisitor.php
+++ b/vendor-extra/LiberoContentBundle/src/ViewConverter/ItalicVisitor.php
@@ -23,9 +23,9 @@ final class ItalicVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/LiberoContentBundle/src/ViewConverter/SubVisitor.php
+++ b/vendor-extra/LiberoContentBundle/src/ViewConverter/SubVisitor.php
@@ -23,9 +23,9 @@ final class SubVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/LiberoContentBundle/src/ViewConverter/SupVisitor.php
+++ b/vendor-extra/LiberoContentBundle/src/ViewConverter/SupVisitor.php
@@ -23,9 +23,9 @@ final class SupVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function possibleTemplate() : string

--- a/vendor-extra/LiberoContentBundle/src/ViewConverter/TitleHeadingVisitor.php
+++ b/vendor-extra/LiberoContentBundle/src/ViewConverter/TitleHeadingVisitor.php
@@ -21,9 +21,9 @@ final class TitleHeadingVisitor implements ViewConverterVisitor
         $this->converter = $converter;
     }
 
-    protected function doVisit(Element $object, View $view, array &$context = []) : View
+    protected function doVisit(Element $object, View $view) : View
     {
-        return $view->withArgument('text', $this->convertChildren($object, $context));
+        return $view->withArgument('text', $this->convertChildren($object, $view->getContext()));
     }
 
     protected function expectedTemplate() : string

--- a/vendor-extra/LiberoContentBundle/tests/ViewConverter/BoldVisitorTest.php
+++ b/vendor-extra/LiberoContentBundle/tests/ViewConverter/BoldVisitorTest.php
@@ -25,12 +25,11 @@ final class BoldVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class BoldVisitorTest extends TestCase
 
         $element = $this->loadElement('<bold xmlns="http://libero.pub">foo</bold>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class BoldVisitorTest extends TestCase
 
         $element = $this->loadElement('<bold xmlns="http://libero.pub">foo</bold>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class BoldVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/bold.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/LiberoContentBundle/tests/ViewConverter/FrontContentHeaderVisitorTest.php
+++ b/vendor-extra/LiberoContentBundle/tests/ViewConverter/FrontContentHeaderVisitorTest.php
@@ -25,12 +25,11 @@ final class FrontContentHeaderVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class FrontContentHeaderVisitorTest extends TestCase
 
         $element = $this->loadElement('<front xmlns="http://libero.pub"><title>foo</title></front>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,16 +63,11 @@ final class FrontContentHeaderVisitorTest extends TestCase
 
         $element = $this->loadElement('<front xmlns="http://libero.pub">foo</front>');
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/content-header.html.twig'),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -86,16 +79,14 @@ final class FrontContentHeaderVisitorTest extends TestCase
 
         $element = $this->loadElement('<front xmlns="http://libero.pub"><title>foo</title></front>');
 
-        $newContext = [];
         $view = $visitor->visit(
             $element,
-            new View('@LiberoPatterns/content-header.html.twig', ['contentTitle' => 'bar']),
-            $newContext
+            new View('@LiberoPatterns/content-header.html.twig', ['contentTitle' => 'bar'])
         );
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertSame(['contentTitle' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -113,8 +104,9 @@ final class FrontContentHeaderVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['bar' => 'baz'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig'), $newContext);
+        $context = ['bar' => 'baz'];
+
+        $view = $visitor->visit($element, new View('@LiberoPatterns/content-header.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/content-header.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -127,6 +119,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['bar' => 'baz'], $newContext);
+        $this->assertSame(['bar' => 'baz'], $view->getContext());
     }
 }

--- a/vendor-extra/LiberoContentBundle/tests/ViewConverter/ItalicVisitorTest.php
+++ b/vendor-extra/LiberoContentBundle/tests/ViewConverter/ItalicVisitorTest.php
@@ -25,12 +25,11 @@ final class ItalicVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class ItalicVisitorTest extends TestCase
 
         $element = $this->loadElement('<i xmlns="http://libero.pub">foo</i>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class ItalicVisitorTest extends TestCase
 
         $element = $this->loadElement('<italic xmlns="http://libero.pub">foo</italic>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class ItalicVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/italic.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/LiberoContentBundle/tests/ViewConverter/SubVisitorTest.php
+++ b/vendor-extra/LiberoContentBundle/tests/ViewConverter/SubVisitorTest.php
@@ -25,12 +25,11 @@ final class SubVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class SubVisitorTest extends TestCase
 
         $element = $this->loadElement('<sub xmlns="http://libero.pub">foo</sub>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class SubVisitorTest extends TestCase
 
         $element = $this->loadElement('<sub xmlns="http://libero.pub">foo</sub>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class SubVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/sub.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/LiberoContentBundle/tests/ViewConverter/SupVisitorTest.php
+++ b/vendor-extra/LiberoContentBundle/tests/ViewConverter/SupVisitorTest.php
@@ -25,12 +25,11 @@ final class SupVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $view = $visitor->visit($element, new View(null));
 
         $this->assertNull($view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class SupVisitorTest extends TestCase
 
         $element = $this->loadElement('<sup xmlns="http://libero.pub">foo</sup>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,12 +63,11 @@ final class SupVisitorTest extends TestCase
 
         $element = $this->loadElement('<sup xmlns="http://libero.pub">foo</sup>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View(null, ['text' => 'bar']), $newContext);
+        $view = $visitor->visit($element, new View(null, ['text' => 'bar']));
 
         $this->assertNull($view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -88,8 +85,9 @@ final class SupVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View(null), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View(null, [], $context));
 
         $this->assertSame('@LiberoPatterns/sup.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -111,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/LiberoContentBundle/tests/ViewConverter/TitleHeadingVisitorTest.php
+++ b/vendor-extra/LiberoContentBundle/tests/ViewConverter/TitleHeadingVisitorTest.php
@@ -25,12 +25,11 @@ final class TitleHeadingVisitorTest extends TestCase
 
         $element = $this->loadElement($xml);
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig'), $newContext);
+        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig'));
 
         $this->assertSame('@LiberoPatterns/heading.html.twig', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     public function nodeProvider() : iterable
@@ -48,12 +47,11 @@ final class TitleHeadingVisitorTest extends TestCase
 
         $element = $this->loadElement('<title xmlns="http://libero.pub">foo</title>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertSame('template', $view->getTemplate());
         $this->assertEmpty($view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -65,16 +63,11 @@ final class TitleHeadingVisitorTest extends TestCase
 
         $element = $this->loadElement('<title xmlns="http://libero.pub">foo</title>');
 
-        $newContext = [];
-        $view = $visitor->visit(
-            $element,
-            new View('@LiberoPatterns/heading.html.twig', ['text' => 'bar']),
-            $newContext
-        );
+        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig', ['text' => 'bar']));
 
         $this->assertSame('@LiberoPatterns/heading.html.twig', $view->getTemplate());
         $this->assertSame(['text' => 'bar'], $view->getArguments());
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -92,8 +85,9 @@ final class TitleHeadingVisitorTest extends TestCase
 XML
         );
 
-        $newContext = ['qux' => 'quux'];
-        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig'), $newContext);
+        $context = ['qux' => 'quux'];
+
+        $view = $visitor->visit($element, new View('@LiberoPatterns/heading.html.twig', [], $context));
 
         $this->assertSame('@LiberoPatterns/heading.html.twig', $view->getTemplate());
         $this->assertEquals(
@@ -115,6 +109,6 @@ XML
             ],
             $view->getArguments()
         );
-        $this->assertSame(['qux' => 'quux'], $newContext);
+        $this->assertSame(['qux' => 'quux'], $view->getContext());
     }
 }

--- a/vendor-extra/ViewsBundle/src/ViewConverter/CallbackVisitor.php
+++ b/vendor-extra/ViewsBundle/src/ViewConverter/CallbackVisitor.php
@@ -18,8 +18,8 @@ final class CallbackVisitor implements ViewConverterVisitor
         $this->callback = $callback;
     }
 
-    public function visit(Element $object, View $view, array &$context = []) : View
+    public function visit(Element $object, View $view) : View
     {
-        return call_user_func_array($this->callback, [$object, $view, &$context]);
+        return call_user_func_array($this->callback, [$object, $view]);
     }
 }

--- a/vendor-extra/ViewsBundle/src/ViewConverter/LangVisitor.php
+++ b/vendor-extra/ViewsBundle/src/ViewConverter/LangVisitor.php
@@ -12,7 +12,7 @@ use Punic\Misc;
 
 final class LangVisitor implements ViewConverterVisitor
 {
-    public function visit(Element $object, View $view, array &$context = []) : View
+    public function visit(Element $object, View $view) : View
     {
         if ($view->hasArgument('attributes') && !empty($view->getArgument('attributes')['lang'])) {
             return $view;
@@ -21,18 +21,18 @@ final class LangVisitor implements ViewConverterVisitor
         $lang = $object->ownerDocument->xpath()
             ->firstOf('ancestor-or-self::*[@xml:lang][1]/@xml:lang', $object);
 
-        if (!$lang instanceof Attribute || $lang->nodeValue === ($context['lang'] ?? null)) {
+        if (!$lang instanceof Attribute || $lang->nodeValue === $view->getContext('lang')) {
             return $view;
         }
 
-        $context['lang'] = $lang->nodeValue;
+        $context = ['lang' => $lang->nodeValue];
         $attributes = ['lang' => $context['lang']];
         $dir = 'right-to-left' === Misc::getCharacterOrder($context['lang']) ? 'rtl' : 'ltr';
-        if (($context['dir'] ?? null) !== $dir) {
+        if ($view->getContext('dir') !== $dir) {
             $context['dir'] = $dir;
             $attributes['dir'] = $dir;
         }
 
-        return $view->withArgument('attributes', $attributes);
+        return $view->withArgument('attributes', $attributes)->withContext($context);
     }
 }

--- a/vendor-extra/ViewsBundle/src/Views/SimplifiedChildVisitor.php
+++ b/vendor-extra/ViewsBundle/src/Views/SimplifiedChildVisitor.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 trait SimplifiedChildVisitor
 {
-    final public function visit(Element $object, View $view, array &$context = []) : View
+    final public function visit(Element $object, View $view) : View
     {
         $currentTemplate = $view->getTemplate();
 
@@ -32,10 +32,10 @@ trait SimplifiedChildVisitor
             $view = $view->withTemplate($this->possibleTemplate());
         }
 
-        return $this->doVisit($object, $view, $context);
+        return $this->doVisit($object, $view);
     }
 
-    abstract protected function doVisit(Element $object, View $view, array &$context = []) : View;
+    abstract protected function doVisit(Element $object, View $view) : View;
 
     abstract protected function possibleTemplate() : string;
 

--- a/vendor-extra/ViewsBundle/src/Views/SimplifiedVisitor.php
+++ b/vendor-extra/ViewsBundle/src/Views/SimplifiedVisitor.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 trait SimplifiedVisitor
 {
-    final public function visit(Element $object, View $view, array &$context = []) : View
+    final public function visit(Element $object, View $view) : View
     {
         if ($this->expectedTemplate() !== $view->getTemplate()) {
             return $view;
@@ -26,10 +26,10 @@ trait SimplifiedVisitor
             }
         }
 
-        return $this->doVisit($object, $view, $context);
+        return $this->doVisit($object, $view);
     }
 
-    abstract protected function doVisit(Element $object, View $view, array &$context = []) : View;
+    abstract protected function doVisit(Element $object, View $view) : View;
 
     abstract protected function expectedTemplate() : string;
 

--- a/vendor-extra/ViewsBundle/src/Views/View.php
+++ b/vendor-extra/ViewsBundle/src/Views/View.php
@@ -6,16 +6,19 @@ namespace Libero\ViewsBundle\Views;
 
 use JsonSerializable;
 use function array_replace_recursive;
+use function is_string;
 
 final class View implements JsonSerializable
 {
     private $arguments;
+    private $context;
     private $template;
 
-    public function __construct(?string $template, array $arguments = [])
+    public function __construct(?string $template, array $arguments = [], array $context = [])
     {
         $this->template = $template;
         $this->arguments = $arguments;
+        $this->context = $context;
     }
 
     public function hasArgument(string $key) : bool
@@ -36,6 +39,20 @@ final class View implements JsonSerializable
     public function getTemplate() : ?string
     {
         return $this->template;
+    }
+
+    public function hasContext(string $key) : bool
+    {
+        return isset($this->context[$key]);
+    }
+
+    public function getContext(?string $key = null)
+    {
+        if (is_string($key)) {
+            return $this->context[$key] ?? null;
+        }
+
+        return $this->context;
     }
 
     public function withArgument(string $key, $value) : View
@@ -65,6 +82,15 @@ final class View implements JsonSerializable
         $view = clone $this;
 
         $view->template = $template;
+
+        return $view;
+    }
+
+    public function withContext(array $context) : View
+    {
+        $view = clone $this;
+
+        $view->context = array_replace_recursive($view->context, $context);
 
         return $view;
     }

--- a/vendor-extra/ViewsBundle/src/Views/ViewConverterRegistry.php
+++ b/vendor-extra/ViewsBundle/src/Views/ViewConverterRegistry.php
@@ -28,17 +28,17 @@ final class ViewConverterRegistry implements ViewConverter
                 );
             }
 
-            return new View('@LiberoPatterns/text.html.twig', ['nodes' => (string) $node]);
+            return new View('@LiberoPatterns/text.html.twig', ['nodes' => (string) $node], $context);
         }
 
-        $view = new View($template, []);
+        $view = new View($template, [], $context);
 
         foreach ($this->visitors as $visitor) {
-            $view = $visitor->visit($node, $view, $context);
+            $view = $visitor->visit($node, $view);
         }
 
         if (!$view->getTemplate()) {
-            return new View('@LiberoPatterns/text.html.twig', ['nodes' => (string) $node]);
+            return new View('@LiberoPatterns/text.html.twig', ['nodes' => (string) $node], $context);
         }
 
         return $view;

--- a/vendor-extra/ViewsBundle/src/Views/ViewConverterVisitor.php
+++ b/vendor-extra/ViewsBundle/src/Views/ViewConverterVisitor.php
@@ -8,5 +8,5 @@ use FluentDOM\DOM\Element;
 
 interface ViewConverterVisitor
 {
-    public function visit(Element $object, View $view, array &$context = []) : View;
+    public function visit(Element $object, View $view) : View;
 }

--- a/vendor-extra/ViewsBundle/tests/ViewConverter/CallbackVisitorTest.php
+++ b/vendor-extra/ViewsBundle/tests/ViewConverter/CallbackVisitorTest.php
@@ -18,7 +18,7 @@ final class CallbackVisitorTest extends TestCase
     public function it_is_a_view_converter_visitor() : void
     {
         $handler = new CallbackVisitor(
-            function (Element $object, View $view, array &$context) : View {
+            function (Element $object, View $view) : View {
                 return $view;
             }
         );
@@ -32,17 +32,13 @@ final class CallbackVisitorTest extends TestCase
     public function it_returns_the_results_of_a_callback() : void
     {
         $element = new Element('foo');
-        $context = ['bar' => 'baz'];
 
         $handler = new CallbackVisitor(
-            function (Element $object, View $view, array &$context) : View {
-                $context['object'] = $object;
-
+            function (Element $object, View $view) : View {
                 return $view->withTemplate('template');
             }
         );
 
-        $this->assertEquals(new View('template'), $handler->visit($element, new View(null), $context));
-        $this->assertEquals(['bar' => 'baz', 'object' => $element], $context);
+        $this->assertEquals(new View('template'), $handler->visit($element, new View(null)));
     }
 }

--- a/vendor-extra/ViewsBundle/tests/ViewConverter/LangVisitorTest.php
+++ b/vendor-extra/ViewsBundle/tests/ViewConverter/LangVisitorTest.php
@@ -23,11 +23,10 @@ final class LangVisitorTest extends TestCase
 
         $element = $this->loadElement('<foo><bar>baz</bar></foo>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template'));
 
         $this->assertFalse($view->hasArgument('attributes'));
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -39,11 +38,10 @@ final class LangVisitorTest extends TestCase
 
         $element = $this->loadElement('<foo xml:lang="fr">bar</foo>');
 
-        $newContext = [];
-        $view = $visitor->visit($element, new View('template', ['attributes' => ['lang' => 'en']]), $newContext);
+        $view = $visitor->visit($element, new View('template', ['attributes' => ['lang' => 'en']]));
 
         $this->assertSame(['lang' => 'en'], $view->getArgument('attributes'));
-        $this->assertEmpty($newContext);
+        $this->assertEmpty($view->getContext());
     }
 
     /**
@@ -63,11 +61,10 @@ final class LangVisitorTest extends TestCase
         /** @var Element $element */
         $element = $document->xpath()->firstOf($selector);
 
-        $newContext = $context;
-        $view = $visitor->visit($element, new View('template'), $newContext);
+        $view = $visitor->visit($element, new View('template', [], $context));
 
         $this->assertSame($expectedAttributes, $view->getArgument('attributes'), 'Attributes do not match');
-        $this->assertSame($expectedContext, $newContext, 'Context does not match');
+        $this->assertSame($expectedContext, $view->getContext(), 'Context does not match');
     }
 
     public function contextProvider() : iterable
@@ -250,12 +247,11 @@ final class LangVisitorTest extends TestCase
         $visitor = new LangVisitor();
 
         $element = $this->loadElement('<foo xml:lang="en">bar</foo>');
+        $context = ['baz' => 'qux'];
 
-        $newContext = ['baz' => 'qux'];
         $view = $visitor->visit(
             $element,
-            new View('template', ['attributes' => ['foo' => 'bar'], 'baz' => 'qux']),
-            $newContext
+            new View('template', ['attributes' => ['foo' => 'bar'], 'baz' => 'qux'], $context)
         );
 
         $this->assertSame(
@@ -264,7 +260,7 @@ final class LangVisitorTest extends TestCase
         );
         $this->assertSame(
             ['baz' => 'qux', 'lang' => 'en', 'dir' => 'ltr'],
-            $newContext
+            $view->getContext()
         );
     }
 }

--- a/vendor-extra/ViewsBundle/tests/Views/ViewConverterRegistryTest.php
+++ b/vendor-extra/ViewsBundle/tests/Views/ViewConverterRegistryTest.php
@@ -67,28 +67,38 @@ final class ViewConverterRegistryTest extends TestCase
 
         $handler->add(
             new CallbackVisitor(
-                function (Element $object, View $view, array &$context = []) : View {
-                    return $view->withTemplate($view->getTemplate().'foo')->withArgument('foo', 'foo');
+                function (Element $object, View $view) : View {
+                    return $view
+                        ->withTemplate($view->getTemplate().'foo')
+                        ->withArgument('foo', 'foo')
+                        ->withContext(['one' => 'foo']);
                 }
             ),
             new CallbackVisitor(
-                function (Element $object, View $view, array &$context = []) : View {
-                    return $view->withTemplate($view->getTemplate().'bar')->withArgument('bar', 'bar');
+                function (Element $object, View $view) : View {
+                    return $view
+                        ->withTemplate($view->getTemplate().'bar')
+                        ->withArgument('bar', 'bar')
+                        ->withContext(['one' => 'bar']);
                 }
             )
         );
 
         $handler->add(
             new CallbackVisitor(
-                function (Element $object, View $view, array &$context = []) : View {
-                    return $view->withTemplate($view->getTemplate().'baz')->withArgument('baz', 'baz');
+                function (Element $object, View $view) : View {
+                    return $view
+                        ->withTemplate($view->getTemplate().'baz')
+                        ->withArgument('baz', 'baz')
+                        ->withContext(['one' => 'baz']);
                 }
             )
         );
 
-        $this->assertEquals(
-            new View('foobarbaz', ['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz']),
-            $handler->convert(new Element('foo'), null, [])
-        );
+        $view = $handler->convert(new Element('element'), 'template', ['con' => 'text', 'one' => 'two']);
+
+        $this->assertEquals('templatefoobarbaz', $view->getTemplate());
+        $this->assertEquals(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], $view->getArguments());
+        $this->assertEquals(['con' => 'text', 'one' => 'baz'], $view->getContext());
     }
 }

--- a/vendor-extra/ViewsBundle/tests/Views/ViewTest.php
+++ b/vendor-extra/ViewsBundle/tests/Views/ViewTest.php
@@ -52,6 +52,29 @@ final class ViewTest extends TestCase
     /**
      * @test
      */
+    public function it_has_context() : void
+    {
+        $view = new View(null, [], ['foo' => 'bar']);
+
+        $this->assertTrue($view->hasContext('foo'));
+        $this->assertFalse($view->hasContext('bar'));
+
+        $this->assertSame('bar', $view->getContext('foo'));
+        $this->assertNull($view->getContext('bar'));
+        $this->assertEquals(['foo' => 'bar'], $view->getContext());
+
+        $view = $view->withContext(['foo' => ['baz' => 'qux']]);
+        $this->assertSame(['baz' => 'qux'], $view->getContext('foo'));
+        $this->assertEquals(['foo' => ['baz' => 'qux']], $view->getContext());
+
+        $view = $view->withContext(['foo' => ['quux' => 'quuz']]);
+        $this->assertSame(['baz' => 'qux', 'quux' => 'quuz'], $view->getContext('foo'));
+        $this->assertEquals(['foo' => ['baz' => 'qux', 'quux' => 'quuz']], $view->getContext());
+    }
+
+    /**
+     * @test
+     */
     public function it_is_json_serializable() : void
     {
         $view = new View('template', ['foo' => 'bar', 'baz' => ['qux']]);


### PR DESCRIPTION
Following https://github.com/libero/browser/pull/47#discussion_r266006504.

Didn't originally do this at the `View` is meant for output, but it did meaning having to pass around `$context` by reference. Could have used a mutable object instead, but #47 is looking like there's use cases for knowing the resulting context elsewhere, like https://github.com/libero/browser/blob/e216d4bc3a50dbeaa62c2f3e7433fff5b8d9e985/vendor-extra/ContentPageBundle/src/Event/CreateContentPagePartEvent.php#L42