### PR TITLE
Add translations directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 /var/
 /vendor/
 ###< symfony/framework-bundle ###
+
+###> symfony/translation ###
+/translations/
+!/translations/.gitkeep
+###< symfony/translation ###

--- a/config/packages/test/translation.yaml
+++ b/config/packages/test/translation.yaml
@@ -1,0 +1,3 @@
+framework:
+    translator:
+        default_path: '%kernel.project_dir%/tests/translations'

--- a/config/packages/test/translation.yaml
+++ b/config/packages/test/translation.yaml
@@ -1,3 +1,3 @@
 framework:
     translator:
-        default_path: '%kernel.project_dir%/tests/translations'
+        default_path: '/var/empty'


### PR DESCRIPTION
Translations can already be mounted in, this makes it a bit more explicit.

Also overrides the path in `test`, as https://github.com/libero/browser/blob/1bc13dc32ccf32480a15cdd97b73a35c15c043a5/tests/WebTest.php#L25 will be testing it.