### PR TITLE
Fix libero/page-bundle tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     },
     "require-dev": {
         "csa/guzzle-cache-middleware": "^1.0",
+        "dusank/knapsack": "^10.0",
         "libero/coding-standard": "^0.4",
         "php-vfs/php-vfs": "^1.4",
         "phpstan/phpstan": "^0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -5267,16 +5267,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.2.5",
+            "version": "v4.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9f87189ac10b42edf7fb8edc846f1937c6d157cf"
+                "reference": "60319b45653580b0cdacca499344577d87732f16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9f87189ac10b42edf7fb8edc846f1937c6d157cf",
-                "reference": "9f87189ac10b42edf7fb8edc846f1937c6d157cf",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/60319b45653580b0cdacca499344577d87732f16",
+                "reference": "60319b45653580b0cdacca499344577d87732f16",
                 "shasum": ""
             },
             "require": {
@@ -5290,7 +5290,6 @@
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "~3.4|~4.0",
                 "symfony/process": "~3.4|~4.0",
                 "twig/twig": "~1.34|~2.4"
             },
@@ -5305,7 +5304,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -5339,7 +5338,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-02-23T15:17:42+00:00"
+            "time": "2018-10-02T16:36:10+00:00"
         },
         {
             "name": "symfony/web-profiler-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "855d900355244020254c69ba7fd32af3",
+    "content-hash": "267569c2b3aec1f927ea42be3c381a8d",
     "packages": [
         {
             "name": "csa/guzzle-bundle",
@@ -2732,6 +2732,64 @@
             "time": "2017-07-22T11:58:36+00:00"
         },
         {
+            "name": "dusank/knapsack",
+            "version": "10.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DusanKasan/Knapsack.git",
+                "reference": "cc29a0bbaadbfcb958b98aa4fd69a4ad7d173bba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DusanKasan/Knapsack/zipball/cc29a0bbaadbfcb958b98aa4fd69a4ad7d173bba",
+                "reference": "cc29a0bbaadbfcb958b98aa4fd69a4ad7d173bba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "ciaranmcnulty/phpspec-typehintedmethods": "^1.0",
+                "henrikbjorn/phpspec-code-coverage": "^2.0",
+                "phpmd/phpmd": "^2.0",
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^5.0",
+                "squizlabs/php_codesniffer": "^2.0",
+                "symfony/console": "^2.7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/collection_functions.php",
+                    "src/utility_functions.php"
+                ],
+                "psr-4": {
+                    "DusanKasan\\Knapsack\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dusan Kasan",
+                    "email": "dusan@kasan.sk",
+                    "homepage": "http://kasan.sk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Collection library for PHP",
+            "homepage": "https://github.com/DusanKasan/Knapsack",
+            "keywords": [
+                "collections",
+                "map",
+                "reduce",
+                "sequences"
+            ],
+            "time": "2017-04-24T22:52:29+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "1.2",
             "source": {
@@ -5209,16 +5267,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.1.7",
+            "version": "v4.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "60319b45653580b0cdacca499344577d87732f16"
+                "reference": "9f87189ac10b42edf7fb8edc846f1937c6d157cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/60319b45653580b0cdacca499344577d87732f16",
-                "reference": "60319b45653580b0cdacca499344577d87732f16",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9f87189ac10b42edf7fb8edc846f1937c6d157cf",
+                "reference": "9f87189ac10b42edf7fb8edc846f1937c6d157cf",
                 "shasum": ""
             },
             "require": {
@@ -5232,6 +5290,7 @@
             },
             "require-dev": {
                 "ext-iconv": "*",
+                "symfony/console": "~3.4|~4.0",
                 "symfony/process": "~3.4|~4.0",
                 "twig/twig": "~1.34|~2.4"
             },
@@ -5246,7 +5305,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -5280,7 +5339,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "symfony/web-profiler-bundle",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,27 +15,15 @@
         <testsuite name="Browser">
             <directory suffix=".php">tests</directory>
         </testsuite>
-        <testsuite name="ContentPageBundle">
-            <directory suffix=".php">vendor-extra/ContentPageBundle/tests</directory>
-        </testsuite>
-        <testsuite name="JatsContentBundle">
-            <directory suffix=".php">vendor-extra/JatsContentBundle/tests</directory>
-        </testsuite>
-        <testsuite name="LiberoContentBundle">
-            <directory suffix=".php">vendor-extra/LiberoContentBundle/tests</directory>
-        </testsuite>
-        <testsuite name="ViewsBundle">
-            <directory suffix=".php">vendor-extra/ViewsBundle/tests</directory>
+        <testsuite name="VendorExtra">
+            <directory suffix=".php">vendor-extra/*/tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
             <directory>src</directory>
-            <directory>vendor-extra/ContentPageBundle/src</directory>
-            <directory>vendor-extra/JatsContentBundle/src</directory>
-            <directory>vendor-extra/LiberoContentBundle/src</directory>
-            <directory>vendor-extra/ViewsBundle/src</directory>
+            <directory>vendor-extra/*/src</directory>
         </whitelist>
     </filter>
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -26,6 +26,9 @@
     "doctrine/instantiator": {
         "version": "1.1.0"
     },
+    "dusank/knapsack": {
+        "version": "10.0.0"
+    },
     "fluentdom/fluentdom": {
         "version": "7.1.0"
     },

--- a/vendor-extra/LiberoPageBundle/tests/TwigTestCase.php
+++ b/vendor-extra/LiberoPageBundle/tests/TwigTestCase.php
@@ -7,6 +7,7 @@ namespace tests\Libero\LiberoPageBundle;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DomCrawler\Crawler;
 use Twig\Environment;
+use function DusanKasan\Knapsack\dump;
 use function GuzzleHttp\json_encode;
 
 trait TwigTestCase
@@ -21,7 +22,7 @@ trait TwigTestCase
         $twig->method('render')
             ->willReturnCallback(
                 function (...$arguments) : string {
-                    return '<html><body>'.json_encode($arguments).'</body></html>';
+                    return '<html><body>'.json_encode(dump($arguments)).'</body></html>';
                 }
             );
 


### PR DESCRIPTION
#52 didn't update PHPUnit configuration to actually enabled the tests; turns out https://github.com/libero/browser/pull/63#discussion_r271599298 wasn't quite true as the tests relied on it.

This fixes the tests, and changes the configuration to hopefully avoid the same problem.