### PR TITLE
Simplify service config

### DIFF
--- a/vendor-extra/JatsContentBundle/src/Resources/config/services.xml
+++ b/vendor-extra/JatsContentBundle/src/Resources/config/services.xml
@@ -8,26 +8,22 @@
 
         <defaults public="false"/>
 
-        <service id="Libero\JatsContentBundle\EventListener\BodyListener"
-            class="Libero\JatsContentBundle\EventListener\BodyListener">
+        <service id="Libero\JatsContentBundle\EventListener\BodyListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.page.create.main" method="onCreatePagePart"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\ContentHeaderListener"
-            class="Libero\JatsContentBundle\EventListener\ContentHeaderListener">
+        <service id="Libero\JatsContentBundle\EventListener\ContentHeaderListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.page.create.main" method="onCreatePagePart" priority="50"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\ItemTagsListener"
-            class="Libero\JatsContentBundle\EventListener\ItemTagsListener">
+        <service id="Libero\JatsContentBundle\EventListener\ItemTagsListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.page.create.main" method="onCreatePagePart" priority="-10"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\TitleListener"
-            class="Libero\JatsContentBundle\EventListener\TitleListener">
+        <service id="Libero\JatsContentBundle\EventListener\TitleListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.page.create" method="onCreatePage"/>
         </service>
@@ -39,41 +35,34 @@
             <tag name="kernel.event_listener" event="libero.page.create" method="onCreatePage" priority="1000"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\PubDateIsoDateTimeListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\PubDateIsoDateTimeListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\PubDateIsoDateTimeListener">
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\PubDatePartsTimeListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\PubDatePartsTimeListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\PubDatePartsTimeListener">
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="-10"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\PubDateTimeListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\PubDateTimeListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\PubDateTimeListener">
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="-100"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\HeadingListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\HeadingListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\HeadingListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\LinkListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\LinkListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\LinkListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="-10"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontItemTagsListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontItemTagsListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontItemTagsListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\KeywordGroupTagListListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\KeywordGroupTagListListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\KeywordGroupTagListListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <argument type="service" id="translator"/>
             <argument type="collection">
@@ -84,21 +73,18 @@
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTitleContentHeaderListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTitleContentHeaderListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTitleContentHeaderListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontContentHeaderMetaListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontContentHeaderMetaListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontContentHeaderMetaListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <argument type="service" id="translator"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTypeContentMetaListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTypeContentMetaListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTypeContentMetaListener">
             <argument type="service" id="translator"/>
             <argument type="collection">
                 <!-- Map of @article-type values to translation keys -->
@@ -107,71 +93,60 @@
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="-100"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontDisplayChannelContentMetaListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontDisplayChannelContentMetaListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontDisplayChannelContentMetaListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <argument type="service" id="translator"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontPubDateContentMetaListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontPubDateContentMetaListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontPubDateContentMetaListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <argument type="service" id="translator"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontSubjectGroupContentHeaderListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontSubjectGroupContentHeaderListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontSubjectGroupContentHeaderListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <argument type="service" id="translator"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\ItalicListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\ItalicListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\ItemTeaserListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\BoldListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\BoldListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTitleTeaserListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\ParagraphListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\ParagraphListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\ParagraphListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\ItemTeaserListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\ItemTeaserListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\SectionListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="50"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTitleTeaserListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\FrontArticleTitleTeaserListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\BoldListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\SectionListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\SectionListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\ItalicListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\SubListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\SubListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\SubListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\JatsContentBundle\EventListener\BuildView\SupListener"
-            class="Libero\JatsContentBundle\EventListener\BuildView\SupListener">
+        <service id="Libero\JatsContentBundle\EventListener\BuildView\SupListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>

--- a/vendor-extra/LiberoContentBundle/src/Resources/config/services.xml
+++ b/vendor-extra/LiberoContentBundle/src/Resources/config/services.xml
@@ -8,62 +8,52 @@
 
         <defaults public="false"/>
 
-        <service id="Libero\LiberoContentBundle\EventListener\ContentHeaderListener"
-            class="Libero\LiberoContentBundle\EventListener\ContentHeaderListener">
+        <service id="Libero\LiberoContentBundle\EventListener\ContentHeaderListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.page.create.main" method="onCreatePagePart" priority="50"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\TitleListener"
-            class="Libero\LiberoContentBundle\EventListener\TitleListener">
+        <service id="Libero\LiberoContentBundle\EventListener\TitleListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.page.create" method="onCreatePage"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\FrontContentHeaderListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\FrontContentHeaderListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\FrontContentHeaderListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\FrontTitleTeaserListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\FrontTitleTeaserListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\FrontTitleTeaserListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\TitleHeadingListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\TitleHeadingListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\TitleHeadingListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\ItemTeaserListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\ItemTeaserListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\ItemTeaserListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="50"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\ItalicListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\ItalicListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\ItalicListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\BoldListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\BoldListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\BoldListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\SubListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\SubListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\SubListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoContentBundle\EventListener\BuildView\SupListener"
-            class="Libero\LiberoContentBundle\EventListener\BuildView\SupListener">
+        <service id="Libero\LiberoContentBundle\EventListener\BuildView\SupListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>

--- a/vendor-extra/LiberoPageBundle/src/Resources/config/services.xml
+++ b/vendor-extra/LiberoPageBundle/src/Resources/config/services.xml
@@ -8,22 +8,19 @@
 
         <defaults public="false"/>
 
-        <service id="Libero\LiberoPageBundle\Controller\PageController"
-            class="Libero\LiberoPageBundle\Controller\PageController">
+        <service id="Libero\LiberoPageBundle\Controller\PageController">
             <argument type="service" id="twig"/>
             <argument>%libero.page_template%</argument>
             <argument type="service" id="event_dispatcher"/>
             <tag name="controller.service_arguments"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\HomepageContentHeaderListener"
-            class="Libero\LiberoPageBundle\EventListener\HomepageContentHeaderListener">
+        <service id="Libero\LiberoPageBundle\EventListener\HomepageContentHeaderListener">
             <argument type="service" id="translator"/>
             <tag name="kernel.event_listener" event="libero.page.create.main" method="onCreatePagePart" priority="50"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\HomepageContentListListener"
-            class="Libero\LiberoPageBundle\EventListener\HomepageContentListListener">
+        <service id="Libero\LiberoPageBundle\EventListener\HomepageContentListListener">
             <argument type="service" id="libero.client"/>
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <argument type="service" id="translator"/>
@@ -31,47 +28,40 @@
             <tag name="kernel.event_listener" event="libero.page.create.main" method="onCreatePagePart"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\TitleListener"
-            class="Libero\LiberoPageBundle\EventListener\TitleListener">
+        <service id="Libero\LiberoPageBundle\EventListener\TitleListener">
             <argument type="service" id="translator"/>
             <tag name="kernel.event_listener" event="libero.page.create" method="onCreatePage" priority="-1000"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\ContentItemListener"
-            class="Libero\LiberoPageBundle\EventListener\ContentItemListener">
+        <service id="Libero\LiberoPageBundle\EventListener\ContentItemListener">
             <argument type="service" id="libero.client"/>
             <tag name="kernel.event_listener" event="libero.page.load" method="onLoadPageData"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemListEmptyListener"
-            class="Libero\LiberoPageBundle\EventListener\BuildView\ItemListEmptyListener">
+        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemListEmptyListener">
             <argument type="service" id="translator"/>
             <!-- After ItemListListener -->
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="-10"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemListListener"
-            class="Libero\LiberoPageBundle\EventListener\BuildView\ItemListListener">
+        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemListListener">
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemListTitleListener"
-            class="Libero\LiberoPageBundle\EventListener\BuildView\ItemListTitleListener">
+        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemListTitleListener">
             <argument type="service" id="translator"/>
             <!-- Before ItemListListener -->
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="10"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemRefTeaserHrefListener"
-            class="Libero\LiberoPageBundle\EventListener\BuildView\ItemRefTeaserHrefListener">
+        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemRefTeaserHrefListener">
             <argument type="service" id="router"/>
             <!-- Before ItemRefTeaserListener -->
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="1"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemRefTeaserListener"
-            class="Libero\LiberoPageBundle\EventListener\BuildView\ItemRefTeaserListener">
+        <service id="Libero\LiberoPageBundle\EventListener\BuildView\ItemRefTeaserListener">
             <argument type="service" id="libero.client"/>
             <argument type="service" id="Libero\ViewsBundle\Views\ViewConverter"/>
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView"/>
@@ -84,20 +74,17 @@
             <tag name="kernel.event_listener" event="libero.page.create" method="onCreatePage" priority="1000"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\MainListener"
-            class="Libero\LiberoPageBundle\EventListener\MainListener">
+        <service id="Libero\LiberoPageBundle\EventListener\MainListener">
             <argument type="service" id="event_dispatcher"/>
             <tag name="kernel.event_listener" event="libero.page.create" method="onCreatePage"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\Routing\PageRouteLoader"
-            class="Libero\LiberoPageBundle\Routing\PageRouteLoader">
+        <service id="Libero\LiberoPageBundle\Routing\PageRouteLoader">
             <argument type="collection"/>
             <tag name="routing.loader"/>
         </service>
 
-        <service id="Libero\LiberoPageBundle\EventListener\LiberoPageListener"
-            class="Libero\LiberoPageBundle\EventListener\LiberoPageListener">
+        <service id="Libero\LiberoPageBundle\EventListener\LiberoPageListener">
             <argument type="collection"/>
             <!-- Immediately after RouterListener -->
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="31"/>

--- a/vendor-extra/ViewsBundle/src/Resources/config/services.xml
+++ b/vendor-extra/ViewsBundle/src/Resources/config/services.xml
@@ -8,16 +8,14 @@
 
         <defaults public="false"/>
 
-        <service id="Libero\ViewsBundle\Views\EventDispatchingViewConverter"
-            class="Libero\ViewsBundle\Views\EventDispatchingViewConverter">
+        <service id="Libero\ViewsBundle\Views\EventDispatchingViewConverter">
             <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Libero\ViewsBundle\Views\ViewConverter"
             alias="Libero\ViewsBundle\Views\EventDispatchingViewConverter"/>
 
-        <service id="Libero\ViewsBundle\EventListener\BuildView\LangListener"
-            class="Libero\ViewsBundle\EventListener\BuildView\LangListener">
+        <service id="Libero\ViewsBundle\EventListener\BuildView\LangListener">
             <tag name="kernel.event_listener" event="libero.view.build" method="onBuildView" priority="100"/>
         </service>
 


### PR DESCRIPTION
`class` isn't needed if the `id` is the classname.