### PR TITLE
Remove debug.event_dispatcher

### DIFF
--- a/vendor-extra/ViewsBundle/src/DependencyInjection/Compiler/RemoveDebugEventDispatcherPass.php
+++ b/vendor-extra/ViewsBundle/src/DependencyInjection/Compiler/RemoveDebugEventDispatcherPass.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Libero\ViewsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RemoveDebugEventDispatcherPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container) : void
+    {
+        $container->removeDefinition('debug.event_dispatcher');
+    }
+}

--- a/vendor-extra/ViewsBundle/src/ViewsBundle.php
+++ b/vendor-extra/ViewsBundle/src/ViewsBundle.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Libero\ViewsBundle;
 
+use Libero\ViewsBundle\DependencyInjection\Compiler\RemoveDebugEventDispatcherPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class ViewsBundle extends Bundle
 {
+    public function build(ContainerBuilder $container) : void
+    {
+        $container->addCompilerPass(new RemoveDebugEventDispatcherPass());
+    }
 }


### PR DESCRIPTION
Extracted from https://github.com/libero/browser/pull/95#discussion_r300619514.

The `dev` environment always has been a lot slower than `prod`, seems to be the profiling of the event dispatcher (generating the data for the patterns sees a _lot_ of events go to a _lot_ of listeners). Adding references sees it collapse entirely (runs out of memory).

This takes a brute-force approach and disables the special event dispatcher used for profiling. Means the 'Performance' profile pane is now empty.

Will try and think of a far better solution, but for now this works.