### PR TITLE
Increase memory limit for PHPStan

### DIFF
--- a/.docker/php-test.ini
+++ b/.docker/php-test.ini
@@ -1,0 +1,1 @@
+memory_limit = 256M

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN touch .phpcs-cache && \
     chown www-data:www-data .phpcs-cache
 COPY tests/ tests/
+COPY .docker/php-test.ini ${PHP_INI_DIR}/conf.d/01-app.ini
 COPY composer.json \
     composer.lock \
     phpcs.xml.dist \
@@ -112,7 +113,7 @@ ENV APP_ENV=dev
 USER root
 ENV COMPOSER_ALLOW_SUPERUSER=true
 
-COPY .docker/php-dev.ini ${PHP_INI_DIR}/conf.d/01-app.ini
+COPY .docker/php-dev.ini ${PHP_INI_DIR}/conf.d/02-app.ini
 
 RUN bin/console assets:install && \
     rm -rf var/*
@@ -144,4 +145,4 @@ FROM dev AS debug
 COPY --from=xdebug ${PHP_EXTENSION_DIR}/*.so ${PHP_EXTENSION_DIR}/
 COPY --from=xdebug ${PHP_INI_DIR}/conf.d/*.ini ${PHP_INI_DIR}/conf.d/
 
-COPY .docker/php-debug.ini ${PHP_INI_DIR}/conf.d/02-app.ini
+COPY .docker/php-debug.ini ${PHP_INI_DIR}/conf.d/03-app.ini


### PR DESCRIPTION
Both #95 and #98 failed as PHPStan runs out of memory. Not sure if it's caused by a bug or not, but this raises the limit.

Unlike https://github.com/libero/browser/pull/95#discussion_r300692929, this does increase it for `dev` too (would have masked #96 for longer).